### PR TITLE
If  '$overwrite' is not true, set '$is_force' as empty string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ define windows_xmltask(
   if ($ensure == 'present') {
     if ($overwrite == true){
       $is_force = '-Force'
+    } else {
+      $is_force = ''
     }
     file {"${xmltask_temp_dir}\\${taskname}.xml":
       ensure             => file,


### PR DESCRIPTION
$is_force variable at the end of "Register-Scheduletask" command was read as string when $overwrite is set 'false'.