### PR TITLE
Could not parse for environment production: undefined method `[]' for false:FalseClass

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,14 +29,14 @@ define windows_xmltask(
         }
       ",
       provider => powershell,
-      onlyif   => "if( ((Get-ScheduledTask '${taskname}') -eq ${literal($null)}) -Or ('${overwrite}' -eq 'true')){ exit 0 }else{ exit 1 }",
+      onlyif   => "if( ((Get-ScheduledTask '${taskname}') -eq \$null) -Or ('${overwrite}' -eq 'true')){ exit 0 }else{ exit 1 }",
       require  => File["${xmltask_temp_dir}\\${taskname}.xml"],
     }
   }else{
     exec { "Removing task ${taskname}":
       command  => "
         Try{
-          Unregister-ScheduledTask -TaskName '${taskname}' -Confirm:${literal($false)}
+          Unregister-ScheduledTask -TaskName '${taskname}' -Confirm:\$false
         }
         Catch{
           exit 0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,6 @@ define windows_xmltask(
     fail("valid values for ensure are 'present' or 'absent'")
   }
 
-  $null  = '$null'
-  $false = '$false'
   if ($ensure == 'present') {
     if ($overwrite == true){
       $is_force = '-Force'
@@ -31,14 +29,14 @@ define windows_xmltask(
         }
       ",
       provider => powershell,
-      onlyif   => "if( ((Get-ScheduledTask '${taskname}') -eq ${null}) -Or ('${overwrite}' -eq 'true')){ exit 0 }else{ exit 1 }",
+      onlyif   => "if( ((Get-ScheduledTask '${taskname}') -eq ${literal($null)}) -Or ('${overwrite}' -eq 'true')){ exit 0 }else{ exit 1 }",
       require  => File["${xmltask_temp_dir}\\${taskname}.xml"],
     }
   }else{
     exec { "Removing task ${taskname}":
       command  => "
         Try{
-          Unregister-ScheduledTask -TaskName '${taskname}' -Confirm:${false}
+          Unregister-ScheduledTask -TaskName '${taskname}' -Confirm:${literal($false)}
         }
         Catch{
           exit 0


### PR DESCRIPTION
In Puppet 5.4 this doesn't parse. It returns a error: 

Could not parse for environment production: undefined method `[]' for false:FalseClass

This seems to fix it for Puppet 5.x